### PR TITLE
Missing dependency for org.apache.http

### DIFF
--- a/gittruckfactor/pom.xml
+++ b/gittruckfactor/pom.xml
@@ -69,5 +69,10 @@
 		    <artifactId>guava</artifactId>
 		    <version>18.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
It looks like [Apache HttpClient 4.5](http://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.5) is missing in the Maven dependencies.
I had the following error when compiling on a fresh Ubuntu machine:
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Truck-Factor/gittruckfactor/src/aserg/gtf/model/LogCommitInfo.java:[17,35] package org.apache.http.impl.client does not exist
[ERROR] /Truck-Factor/gittruckfactor/src/aserg/gtf/util/AliasesIdentifier.java:[12,28] package org.apache.http.auth does not exist
[INFO] 2 errors
```

Version 4.5 seems required to get `AIMDBackoffManager`.
(with version 4.0:)
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project gitdownloader: Compilation failure
[ERROR] /Truck-Factor/gittruckfactor/src/aserg/gtf/model/LogCommitInfo.java:[17,35] cannot find symbol
[ERROR] symbol:   class AIMDBackoffManager
[ERROR] location: package org.apache.http.impl.client
```